### PR TITLE
add invoke on object method

### DIFF
--- a/include/cpgf/scriptbind/gscriptbindapi.h
+++ b/include/cpgf/scriptbind/gscriptbindapi.h
@@ -32,6 +32,9 @@ struct IScriptFunction : public IExtendObject
 public:
 	virtual void G_API_CC invoke(GScriptValueData * outResult, const GVariantData * params, uint32_t paramCount) = 0;
 	virtual void G_API_CC invokeIndirectly(GScriptValueData * outResult, GVariantData const * const * params, uint32_t paramCount) = 0;
+	virtual void G_API_CC invokeOnObject(GScriptValueData * outResult, const GVariantData * params, uint32_t paramCount) = 0;
+	virtual void G_API_CC invokeIndirectlyOnObject(GScriptValueData * outResult, GVariantData const * const * params, uint32_t paramCount) = 0;
+
 	// Internal use only!!!
 	virtual void G_API_CC weaken() = 0;
 };

--- a/include/cpgf/scriptbind/gscriptbindutil.h
+++ b/include/cpgf/scriptbind/gscriptbindutil.h
@@ -11,7 +11,8 @@ namespace cpgf {
 #define DECLARE_CALL_HELPER(N, unused) \
 	GScriptValue invokeScriptFunction(GScriptObject * scriptObject, const char * functionName GPP_COMMA_IF(N) GPP_REPEAT_PARAMS(N, const GTypedVariant & p)); \
 	GScriptValue invokeScriptFunction(IScriptObject * scriptObject, const char * functionName GPP_COMMA_IF(N) GPP_REPEAT_PARAMS(N, const GTypedVariant & p)); \
-	GScriptValue invokeScriptFunction(IScriptFunction * scriptFunction GPP_COMMA_IF(N) GPP_REPEAT_PARAMS(N, const GTypedVariant & p));
+	GScriptValue invokeScriptFunction(IScriptFunction * scriptFunction GPP_COMMA_IF(N) GPP_REPEAT_PARAMS(N, const GTypedVariant & p)); \
+	GScriptValue invokeScriptFunctionOnObject(IScriptFunction * scriptFunction GPP_COMMA_IF(N) GPP_REPEAT_PARAMS(N, const GTypedVariant & p));
 
 GPP_REPEAT_2(REF_MAX_ARITY, DECLARE_CALL_HELPER, GPP_EMPTY())
 

--- a/src/pinclude/gbindcommon.h
+++ b/src/pinclude/gbindcommon.h
@@ -35,6 +35,7 @@ public:
 
 	virtual GScriptValue invoke(const GVariant * params, size_t paramCount) = 0;
 	virtual GScriptValue invokeIndirectly(GVariant const * const * params, size_t paramCount) = 0;
+	virtual GScriptValue invokeIndirectlyOnObject(GVariant const * const * params, size_t paramCount) { return invokeIndirectly(params, paramCount); };
 
 	// internal use
 	virtual void weaken() = 0;

--- a/src/pinclude/gscriptbindapiimpl.h
+++ b/src/pinclude/gscriptbindapiimpl.h
@@ -65,6 +65,8 @@ protected:
 
 	virtual void G_API_CC invoke(GScriptValueData * outResult, const GVariantData * params, uint32_t paramCount);
 	virtual void G_API_CC invokeIndirectly(GScriptValueData * outResult, GVariantData const * const * params, uint32_t paramCount);
+	virtual void G_API_CC invokeOnObject(GScriptValueData * outResult, const GVariantData * params, uint32_t paramCount);
+	virtual void G_API_CC invokeIndirectlyOnObject(GScriptValueData * outResult, GVariantData const * const * params, uint32_t paramCount);
 	// Internal use only!!!
 	virtual void G_API_CC weaken();
 

--- a/src/scriptbind/gscriptbindapi.cpp
+++ b/src/scriptbind/gscriptbindapi.cpp
@@ -112,6 +112,41 @@ void G_API_CC ImplScriptFunction::invokeIndirectly(GScriptValueData * outResult,
 	LEAVE_BINDING_API()
 }
 
+void G_API_CC ImplScriptFunction::invokeOnObject(GScriptValueData * outResult, const GVariantData * params, uint32_t paramCount)
+{
+	ENTER_BINDING_API()
+
+	const GVariantData * paramIndirect[REF_MAX_ARITY];
+
+	for(uint32_t i = 0; i < paramCount; ++i) {
+		paramIndirect[i] = &params[i];
+	}
+
+	this->invokeIndirectlyOnObject(outResult, paramIndirect, paramCount);
+
+	LEAVE_BINDING_API()
+}
+
+void G_API_CC ImplScriptFunction::invokeIndirectlyOnObject(GScriptValueData * outResult, GVariantData const * const * params, uint32_t paramCount)
+{
+	ENTER_BINDING_API()
+
+	GVariant paramVariants[REF_MAX_ARITY];
+	const GVariant * paramIndirect[REF_MAX_ARITY];
+
+	for(uint32_t i = 0; i < paramCount; ++i) {
+		paramVariants[i] = createVariantFromData(*params[i]);
+		paramIndirect[i] = &paramVariants[i];
+	}
+
+	GScriptValue result = this->scriptFunction->invokeIndirectlyOnObject(paramIndirect, paramCount);
+	if(outResult) {
+		*outResult = result.takeData();
+	}
+
+	LEAVE_BINDING_API()
+}
+
 // Internal use only!!!
 void G_API_CC ImplScriptFunction::weaken()
 {

--- a/src/scriptbind/gscriptbindutil.cpp
+++ b/src/scriptbind/gscriptbindutil.cpp
@@ -32,26 +32,34 @@ GScriptValue createScriptValueFromData(const GScriptValueData & data);
 	} \
 	GScriptValue invokeScriptFunction(IScriptObject * scriptObject, const char * functionName GPP_COMMA_IF(N) GPP_REPEAT_PARAMS(N, const GTypedVariant & p)) { \
 		DEF_LOAD_PARAM_API(N) \
-	    GScriptValueData data; \
+		GScriptValueData data; \
 		GSharedInterface<IScriptObject> holder(scriptObject); /* Hold the object so metaCheckError won't crash if scriptObject is freed in invoke */ \
 		scriptObject->invoke(&data, functionName, params, N); \
 		metaCheckError(scriptObject); \
-	    return createScriptValueFromData(data); \
+		return createScriptValueFromData(data); \
 	} \
 	GScriptValue invokeScriptFunction(IScriptFunction * scriptFunction GPP_COMMA_IF(N) GPP_REPEAT_PARAMS(N, const GTypedVariant & p)) { \
 		DEF_LOAD_PARAM_API(N) \
-	    GScriptValueData data; \
+		GScriptValueData data; \
 		GSharedInterface<IScriptFunction> holder(scriptFunction); /* Hold the function so metaCheckError won't crash if scriptFunction is freed in invoke */ \
 		scriptFunction->invoke(&data, params, N); \
 		metaCheckError(scriptFunction); \
-	    return createScriptValueFromData(data); \
+		return createScriptValueFromData(data); \
+	} \
+	GScriptValue invokeScriptFunctionOnObject(IScriptFunction * scriptFunction GPP_COMMA_IF(N) GPP_REPEAT_PARAMS(N, const GTypedVariant & p)) { \
+		DEF_LOAD_PARAM_API(N) \
+		GScriptValueData data; \
+		GSharedInterface<IScriptFunction> holder(scriptFunction); /* Hold the function so metaCheckError won't crash if scriptFunction is freed in invoke */ \
+		scriptFunction->invokeOnObject(&data, params, N); \
+		metaCheckError(scriptFunction); \
+		return createScriptValueFromData(data); \
 	}
 
 GPP_REPEAT_2(REF_MAX_ARITY, DEF_CALL_HELPER, GPP_EMPTY())
 
 
 inline bool isCSymbol(unsigned char c) {
-    return isalpha(c) || c == '_' || isdigit(c);
+	return isalpha(c) || c == '_' || isdigit(c);
 }
 
 std::string normalizeReflectName(const char * name)
@@ -193,15 +201,15 @@ IScriptObject * scriptObjectToInterface(GScriptObject * scriptObject)
 void injectObjectToScript(IScriptObject * scriptObject, IMetaClass * metaClass, void * instance, const char * namespaceName)
 {
 	GScopedInterface<IObject> metaObject;
-	
+
 	GMetaMapClass mapClass(metaClass);
-	
+
 	GScopedInterface<IScriptObject> namespaceHolder;
 	if(namespaceName != NULL && *namespaceName) {
 		namespaceHolder.reset(scriptCreateScriptObject(scriptObject, namespaceName).toScriptObject());
 		scriptObject = namespaceHolder.get();
 	}
-	
+
 	const GMetaMapClass::MapType * mapData = mapClass.getMap();
 	for(GMetaMapClass::MapType::const_iterator it = mapData->begin(); it != mapData->end(); ++it) {
 		const char * name = it->first;
@@ -249,7 +257,7 @@ void injectObjectToScript(IScriptObject * scriptObject, IMetaClass * metaClass, 
 				break;
 		}
 	}
-	
+
 }
 
 void injectObjectToScript(GScriptObject * scriptObject, IMetaClass * metaClass, void * instance, const char * namespaceName)

--- a/src/scriptbind/gv8bind.cpp
+++ b/src/scriptbind/gv8bind.cpp
@@ -122,6 +122,7 @@ public:
 
 	virtual GScriptValue invoke(const GVariant * params, size_t paramCount);
 	virtual GScriptValue invokeIndirectly(GVariant const * const * params, size_t paramCount);
+	virtual GScriptValue invokeIndirectlyOnObject(GVariant const * const * params, size_t paramCount);
 
 private:
 	Persistent<Object> receiver;
@@ -1164,6 +1165,17 @@ GScriptValue GV8ScriptFunction::invokeIndirectly(GVariant const * const * params
 	return invokeV8FunctionIndirectly(this->getBindingContext(), receiver, Local<Function>::New(getV8Isolate(), this->func), params, paramCount, "");
 }
 
+GScriptValue GV8ScriptFunction::invokeIndirectlyOnObject(GVariant const * const * params, size_t paramCount)
+{
+	GASSERT_MSG(paramCount >= 1, "Object needs to be specified as the first param.");
+	HandleScope handleScope(getV8Isolate());
+
+	Handle<Value> receiverValue = variantToV8(this->getBindingContext(), *params[0], GBindValueFlags(bvfAllowRaw), NULL);
+	GASSERT_MSG(!receiverValue.IsEmpty() && receiverValue->IsObject(), "Object needs to be specified as the first param.");
+	Local<Object> receiver = receiverValue.As<Object>();
+
+	return invokeV8FunctionIndirectly(this->getBindingContext(), receiver, Local<Function>::New(getV8Isolate(), this->func), &(params[1]), paramCount-1, "");
+}
 
 GV8ScriptArray::GV8ScriptArray(const GContextPointer & context, Handle<Array> arr)
 	: super(context), arrayObject(getV8Isolate(), arr)

--- a/test/metagen/metadata/include/meta_test_simpleoverridefromscript.h
+++ b/test/metagen/metadata/include/meta_test_simpleoverridefromscript.h
@@ -45,7 +45,7 @@ public:
         cpgf::GScopedInterface<cpgf::IScriptFunction> func(this->getScriptFunction("createHelperData"));
         if(func)
         {
-            cpgf::GScriptValue ret = cpgf::invokeScriptFunction(func.get(), this);
+            cpgf::GScriptValue ret = cpgf::invokeScriptFunctionOnObject(func.get(), this);
             ret.discardOwnership();
             return cpgf::fromVariant<SimpleOverrideHelperData * >(ret.getValue());
         }
@@ -61,7 +61,7 @@ public:
         cpgf::GScopedInterface<cpgf::IScriptFunction> func(this->getScriptFunction("getAnother"));
         if(func)
         {
-            return cpgf::fromVariant<int >(cpgf::invokeScriptFunction(func.get(), this).getValue());
+            return cpgf::fromVariant<int >(cpgf::invokeScriptFunctionOnObject(func.get(), this).getValue());
         }
         return SimpleOverride::getAnother();
     }
@@ -75,7 +75,7 @@ public:
         cpgf::GScopedInterface<cpgf::IScriptFunction> func(this->getScriptFunction("getValue"));
         if(func)
         {
-            return cpgf::fromVariant<int >(cpgf::invokeScriptFunction(func.get(), this).getValue());
+            return cpgf::fromVariant<int >(cpgf::invokeScriptFunctionOnObject(func.get(), this).getValue());
         }
         return SimpleOverride::getValue();
     }
@@ -89,7 +89,7 @@ public:
         cpgf::GScopedInterface<cpgf::IScriptFunction> func(this->getScriptFunction("getName"));
         if(func)
         {
-            return cpgf::fromVariant<std::string >(cpgf::invokeScriptFunction(func.get(), this).getValue());
+            return cpgf::fromVariant<std::string >(cpgf::invokeScriptFunctionOnObject(func.get(), this).getValue());
         }
         return SimpleOverride::getName();
     }

--- a/test/metagen/tests/test_metagen_simpleoverridefromscript.cpp
+++ b/test/metagen/tests/test_metagen_simpleoverridefromscript.cpp
@@ -16,7 +16,11 @@ void doTestSimpleOverrideFromScript_OverrideFromScriptClass(T * binding, TestScr
 		QDO(function overrideGetValue(me) return me.super_getValue() + 15 end)
 		QDO(function overrideGetName(me) return "abc" end)
 	}
-	if(context->isV8() || context->isSpiderMonkey()) {
+	if(context->isV8()) {
+		QDO(function overrideGetValue() { return this.super_getValue() + 15; })
+		QDO(function overrideGetName() { return "abc"; })
+	}
+	if(context->isSpiderMonkey()) {
 		QDO(function overrideGetValue(me) { return me.super_getValue() + 15; })
 		QDO(function overrideGetName(me) { return "abc"; })
 	}
@@ -78,7 +82,12 @@ void doTestSimpleOverrideFromScript_OverrideFromScriptObject(T * binding, TestSc
 		QDO(function overrideGetValue(me) return me.super_getValue() + 5 end)
 		QDO(function overrideGetName(me) return "abc" end)
 	}
-	if(context->isV8() || context->isSpiderMonkey()) {
+	if(context->isV8()) {
+		QDO(function overrideGetValue() { return 2 + 5; })
+		QDO(function overrideGetName() { return "abc"; })
+		QDO(function overrideGetAnother() { return 2; })
+	}
+	if(context->isSpiderMonkey()) {
 		QDO(function overrideGetValue(me) { return 2 + 5; })
 		QDO(function overrideGetName(me) { return "abc"; })
 		QDO(function overrideGetAnother(me) { return 2; })

--- a/tools/metagen/tool/src/org/cpgf/metagen/metawriter/ClassWrapperWriter.java
+++ b/tools/metagen/tool/src/org/cpgf/metagen/metawriter/ClassWrapperWriter.java
@@ -89,7 +89,7 @@ public class ClassWrapperWriter {
 		codeWriter.writeLine("cpgf::GScopedInterface<cpgf::IScriptFunction> func(this->getScriptFunction(\"" + cppMethod.getLiteralName() + "\"));");
 		codeWriter.writeLine("if(func)");
 		codeWriter.beginBlock();
-		String invoke = "cpgf::invokeScriptFunction(func.get(), this";
+		String invoke = "cpgf::invokeScriptFunctionOnObject(func.get(), this";
 		if(cppMethod.hasParameter()) {
 			invoke = invoke + ", " + paramText;
 		}


### PR DESCRIPTION
This PR allows script wrappers to override methods w/o requiring to use `$this` as the first parameter of the method, but simply using `this.___` in the client code.

currently only V8 engine is adapted to use this functionality, others use backward compatible callback and the usage is unchanged.
