### PR TITLE
fix segfault when using user converter

### DIFF
--- a/src/scriptbind/gscriptvalue.cpp
+++ b/src/scriptbind/gscriptvalue.cpp
@@ -388,7 +388,9 @@ GScriptValueDataScopedGuard::GScriptValueDataScopedGuard(const GScriptValueData 
 
 GScriptValueDataScopedGuard::~GScriptValueDataScopedGuard()
 {
-	GScriptValue(this->data);
+	if(data.metaItem != NULL) {
+		data.metaItem->releaseReference();
+	}
 }
 
 


### PR DESCRIPTION
as the usage clients only use `get` instead of `take`, we shouldn't destroy the object completely, only release the specific functionality that was allocated.

this fixes segfaults on subsequent usage of the variant data in the params matcher
