### PR TITLE
Added <stdlib.h> header include in gcontainer.h

### DIFF
--- a/include/cpgf/gcontainer.h
+++ b/include/cpgf/gcontainer.h
@@ -11,7 +11,7 @@
 
 #include <math.h>
 #include <assert.h>
-
+#include <stdlib.h>
 
 namespace cpgf {
 


### PR DESCRIPTION
it is required for srand when building with emscripten
