### PR TITLE
Fix setting the class for an object address

### DIFF
--- a/src/scriptbind/gbindcommon.cpp
+++ b/src/scriptbind/gbindcommon.cpp
@@ -462,13 +462,9 @@ GClassPool::GClassPool(GBindingContext * context)
 
 void GClassPool::objectCreated(const GObjectInstancePointer & objectData)
 {
-	// Only store the object data that owns the object (allow gc or it's a shadow object)
-	// If don't check for this, things goes messy if we get the first element address in object array, where two kinds of objects share the same address
-	if(objectData->isAllowGC() || objectData->getInstance().getType() == vtShadow) {
-		void * instance = getInstanceHash(objectData->getInstance());
-		if(this->instanceMap.find(instance) == instanceMap.end()) {
-			this->instanceMap[instance] = GWeakObjectInstancePointer(objectData);
-		}
+	void * instance = getInstanceHash(objectData->getInstance());
+	if(this->instanceMap.find(instance) == instanceMap.end()) {
+		this->instanceMap[instance] = GWeakObjectInstancePointer(objectData);
 	}
 }
 

--- a/test/scriptbind/general/bind_general_override_from_script.cpp
+++ b/test/scriptbind/general/bind_general_override_from_script.cpp
@@ -69,6 +69,7 @@ void doTestOverrideCppFunctionOnNativePtrFromScriptClass(T * binding, TestScript
 	binding->getContext()->bindExternalObjectToClass(&obj, scriptClass);
 
 	GEQUAL(83, obj.getValue());
+	GEQUAL(83, obj.getValue()); // repeat the query to avoid caches
 }
 
 void testOverrideCppFunctionOnNativePtrFromScriptClass(TestScriptContext * context)


### PR DESCRIPTION
The removed check for isAllowGC allows storing a object
class to an object using `bindExternalObjectToClass`.

The errors mentioned in the removed comment are already being
tested in `testObjectArray` and are fixed elsewhere.
