### PR TITLE
setValueOnNamedMember now traverses superclasses

### DIFF
--- a/src/scriptbind/gbindcommon.cpp
+++ b/src/scriptbind/gbindcommon.cpp
@@ -1750,7 +1750,7 @@ bool setValueOnNamedMember(const GGlueDataPointer & instanceGlueData, const char
 			return false;
 		}
 
-		GMetaMapClass * mapClass = classData->getClassMap();
+		GMetaMapClass * mapClass = context->getClassData(metaClass.get())->getClassMap();
 		if(! mapClass) {
 			continue;
 		}


### PR DESCRIPTION
I noticed that my subclasses were not properly inheriting
the setters of their parent classes in lua. After looking
at the code, it appears there is some attempt to traverse
the class heirarchy in setValueOnNamedMember, but it was
not looking up the member in the current class properly.

This seems to fix it, but I haven't done very extensive
testing yet. I wanted to double check that this wasn't
by design before I put more time into it.
