### PR TITLE
Allow overriding of script functions in GScriptDataHolder

### DIFF
--- a/src/scriptbind/gbindcommon.cpp
+++ b/src/scriptbind/gbindcommon.cpp
@@ -433,7 +433,9 @@ void GScriptDataHolder::setScriptValue(const char * name, const GScriptValue & v
 
 	this->requireDataMap();
 
-	this->dataMap->insert(MapValueType(name, value.getValue()));
+  // Insert and overwrite the previous function if it exists.
+  (*this->dataMap)[name] = value.getValue();
+
 	gdynamic_cast<IScriptFunction *>(fromVariant<IObject *>(value.getValue()))->weaken();
 }
 

--- a/test/scriptbind/general/bind_general_override_from_script.cpp
+++ b/test/scriptbind/general/bind_general_override_from_script.cpp
@@ -12,12 +12,15 @@ void doTestOverrideCppFunctionFromScriptClass(T * binding, TestScriptContext * c
 {
 	if(context->isLua()) {
 		QDO(function funcOverride(me) return me.n + 15 end)
+		QDO(function funcOverrideSecond(me) return me.n + 16 end)
 	}
 	if(context->isV8() || context->isSpiderMonkey()) {
 		QDO(function funcOverride(me) { return me.n + 15; })
+		QDO(function funcOverrideSecond(me) { return me.n + 16; })
 	}
 	if(context->isPython()) {
 		QDO(def funcOverride(me): return me.n + 15)
+		QDO(def funcOverrideSecond(me): return me.n + 16)
 	}
 
 	QNEWOBJ(a, ScriptOverride(3))
@@ -27,6 +30,9 @@ void doTestOverrideCppFunctionFromScriptClass(T * binding, TestScriptContext * c
 
 	ScriptOverride * objA = static_cast<ScriptOverride *>(scriptGetValue(binding, "a").toObjectAddress(NULL, NULL));
 	GEQUAL(18, objA->getValue());
+
+  QDO(ScriptOverride.getValue = funcOverrideSecond)
+  QASSERT(a.getValue() == 19);
 }
 
 void testOverrideCppFunctionFromScriptClass(TestScriptContext * context)


### PR DESCRIPTION
Before this change, it was not possible to instantiate a script object from a C++ object and override the same method twice. Added unit tests and confirmed they pass with Lua bindings.
