### PR TITLE
Change castFromString so it can cast to constant string references

### DIFF
--- a/include/cpgf/private/gvariant_p.h
+++ b/include/cpgf/private/gvariant_p.h
@@ -508,13 +508,19 @@ struct CheckIsConvertibleToCharPointer
 };
 
 template <typename T>
-T castFromString(char * s, typename GEnableIfResult<CheckIsConvertibleToCharPointer<T> >::Result * = 0)
+T castFromString(std::string * s, typename GEnableIfResult<CheckIsConvertibleToCharPointer<T> >::Result * = 0)
 {
-	return T(s);
+	return T(s->c_str());
+}
+
+template <>
+inline const std::string& castFromString(std::string * s, void *)
+{
+	return *s;
 }
 
 template <typename T>
-T castFromString(char * /*s*/, typename GDisableIfResult<CheckIsConvertibleToCharPointer<T> >::Result * = 0)
+T castFromString(std::string * s /*s*/, typename GDisableIfResult<CheckIsConvertibleToCharPointer<T> >::Result * = 0)
 {
 	raiseCoreException(Error_Variant_FailCast);
 #if __has_builtin(__builtin_trap)
@@ -783,7 +789,7 @@ struct CastFromVariant
 				return castFromObject<T>(v.refData().shadowObject->getObject());
 
 			case vtString:
-				return castFromString<ResultType>(const_cast<char *>(static_cast<std::string *>(v.refData().shadowObject->getObject())->c_str()));
+				return castFromString<ResultType>(static_cast<std::string *>(v.refData().shadowObject->getObject()));
 
 			case vtWideString:
 				return castFromWideString<ResultType>(const_cast<wchar_t *>(static_cast<std::wstring *>(v.refData().shadowObject->getObject())->c_str()));


### PR DESCRIPTION
Before this change, constant string references were initialized from temporary stack allocated strings and deallocated before they were used as a result. This may have passed tests intermittently. It was especially noticeable for me when using longer strings as they were more likely to be corrupted by the time they were used.

I'd like to write tests for this, but getting the build system setup to run tests is non-trivial as a result of hard coded paths. I did it once before but have since nuked the source tree. I'll try and get around to it soon, but it's a little painful for a small change like this so I may wait until I have a few more.
