### PR TITLE
Add additional tested compilers to README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -122,6 +122,8 @@ To build the unit test and sample code, feed a second parameter
 	TARGET=sampleirrlicht        Build the Irrlicht binding sample application.
 
 ## Compatibility -- Tested compilers and OSes
+* Linux (Ubuntu 18.04), GCC 7.3.0
+* Linux (Ubuntu 18.04, LLVM Clang 5.0.2
 * The below cases were based on the old 1.5 version. Since version 1.6, C++11 compiler is required, and VC 2015 and GCC 4.9.1 were tested.
 * Windows XP, Microsoft Visual C++ 2008 Express and Microsoft Visual C++ 2010 Professional
 * Windows XP, MingW GCC 3.4.2, 4.4.0 and 4.5.2


### PR DESCRIPTION
Based on the previous (accepted) PR, I can now certify that CPGF 1.6.0, as well as the `master` branch, work on Ubuntu 18.04 with both GCC 7 and Clang 5.

Because my company uses CPGF in prod, we will continue to test against those compilers (and/or later versions thereof) on Ubuntu 18.04.